### PR TITLE
Login with email if account differs

### DIFF
--- a/splinterlandsPage.js
+++ b/splinterlandsPage.js
@@ -4,7 +4,7 @@ async function login(page) {
         await page.waitForSelector('#email')
             .then(() => page.waitForTimeout(3000))
             .then(() => page.focus('#email'))
-            .then(() => page.type('#email', process.env.ACCOUNT))
+            .then(() => page.type('#email', process.env.EMAIL || process.env.ACCOUNT))
             .then(() => page.focus('#password'))
             .then(() => page.type('#password', process.env.PASSWORD))
 


### PR DESCRIPTION
I'm not sure if I'm missing something but current code seems to be expecting account name to be the first part of an email. Adding another field for those unlucky whos account name differs from email.