### PR TITLE
Filter out delegated cards

### DIFF
--- a/user.js
+++ b/user.js
@@ -4,7 +4,7 @@ const basicCards = require('./data/basicCards'); //phantom cards available for t
 getPlayerCards = (username) => (fetch(`https://game-api.splinterlands.io/cards/collection/${username}`,
   { "credentials": "omit", "headers": { "accept": "application/json, text/javascript, */*; q=0.01" }, "referrer": `https://splinterlands.com/?p=collection&a=${username}`, "referrerPolicy": "no-referrer-when-downgrade", "body": null, "method": "GET", "mode": "cors" })
   .then(x => x && x.json())
-  .then(x => x['cards'] ? x['cards'].map(card => card.card_detail_id) : '')
+  .then(x => x['cards'] ? x['cards'].filter(card => [null, process.env.ACCOUNT].includes(card.delegated_to)).map(card => card.card_detail_id) : '')
   .then(advanced => basicCards.concat(advanced))
   .catch(e => {console.log('Using only basic cards due to error when getting user collection from splinterlands: ',e); return basicCards})
 )


### PR DESCRIPTION
Facing the following issue time to time:

```
BEST SUMMONER and TANK {
  bestSummoner: '38',
  summonerWins: 8,
  tankWins: 3,
  bestTank: '36',
  bestBackline: '91',
  backlineWins: 2,
  bestSecondBackline: '35',
  secondBacklineWins: 2,
  bestThirdBackline: '',
  thirdBacklineWins: 2
}
BEST TEAM [
  38, 36,     91,
  35, '',     '',
  '', 'life'
]
Play this for the quest: [ '38', [
    38, 36,     91,
    35, '',     '',
    '', 'life'
  ] ]
play:  36
play:  91
play:  35
play:
nocard  4
play:
nocard  5
play:
nocard  6
/Users/user/Git/splinterlands-bot/node_modules/puppeteer/lib/cjs/puppeteer/common/DOMWorld.js:509
            const timeoutError = new Errors_js_1.TimeoutError(`waiting for ${options.title} failed: timeout ${options.timeout}ms exceeded`);
                                 ^

TimeoutError: waiting for XPath `//div[@card_detail_id="91"]` failed: timeout 10000ms exceeded
    at new WaitTask (/Users/user/Git/splinterlands-bot/node_modules/puppeteer/lib/cjs/puppeteer/common/DOMWorld.js:509:34)
    at DOMWorld.waitForXPath (/Users/user/Git/splinterlands-bot/node_modules/puppeteer/lib/cjs/puppeteer/common/DOMWorld.js:445:26)
    at Frame.waitForXPath (/Users/user/Git/splinterlands-bot/node_modules/puppeteer/lib/cjs/puppeteer/common/FrameManager.js:865:51)
    at Page.waitForXPath (/Users/user/Git/splinterlands-bot/node_modules/puppeteer/lib/cjs/puppeteer/common/Page.js:2289:33)
    at startBotPlayMatch (/Users/user/Git/splinterlands-bot/index.js:152:46)
    at async /Users/user/Git/splinterlands-bot/index.js:208:13
```

Card 91 is delegated to other user, making it unplayable effectively.

This works for me though I have very limited experience with JS and I've seen there are other methods available which may work better.