### PR TITLE
dragonBugFix plus Favourite deck to play feature

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -5,5 +5,6 @@ CLAIM_SEASON_REWARD=false
 CLAIM_DAILY_QUEST_REWARD=true
 #ECR_STOP_LIMIT=50 
 #ECR_RECOVER_TO=99
+#FAVOURITE_DECK=dragon #choose only one splinter among: fire, life, earth, water, death, dragon
 ACCOUNT=lowercase_username
 PASSWORD=postingkey

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ By default, the BOT doesn't check for season rewards but it can automatically cl
 By default, the BOT checks automatically for daily quest rewards but the claim option can be deactivated with the option `CLAIM_DAILY_QUEST_REWARD` is set to false. The default option is true.
 By default, the BOT will run as headless. Set `HEADLESS` to false to see your browser. The default option is true
 By default, the BOT will run no matter the ECR level. Set `ECR_STOP_LIMIT` to a specific value you want the bot to rest and recover the ECR. The bot will recover until the `ECR_RECOVER_TO` is reached or until 100% ECR.
-
+If you want the bot to play only one color (when it's possible), use the variable `FAVOURITE_DECK`  and specify the splinter by choosing only one among: fire, life, earth, water, death, dragon. 
 
 Example:
 
@@ -54,6 +54,8 @@ Example:
 - `ECR_STOP_LIMIT=50`
 
 - `ECR_RECOVER_TO=99`
+
+- `FAVOURITE_DECK=dragon`
 
 
 

--- a/helper.js
+++ b/helper.js
@@ -53,7 +53,6 @@ const getElementTextByXpath = async (page, selector, timeout=20000) => {
 	return text;
 }
 
-
 module.exports.teamActualSplinterToPlay = teamActualSplinterToPlay;
 module.exports.clickOnElement = clickOnElement;
 module.exports.getElementText = getElementText;

--- a/index.js
+++ b/index.js
@@ -219,7 +219,7 @@ async function startBotPlayMatch(page) {
     }
     
     //TEAM SELECTION
-    const teamToPlay = await ask.teamSelection(possibleTeams, matchDetails, quest);
+    const teamToPlay = await ask.teamSelection(possibleTeams, matchDetails, quest, page.favouriteDeck);
 
     if (teamToPlay) {
         page.click('.btn--create-team')[0];
@@ -237,8 +237,9 @@ async function startBotPlayMatch(page) {
                 page.waitForXPath(`//div[@card_detail_id="${teamToPlay.summoner}"]`, { timeout: 10000 }).then(summonerButton => summonerButton.click())
             });
         if (card.color(teamToPlay.cards[0]) === 'Gold') {
-            console.log('Dragon play TEAMCOLOR', teamActualSplinterToPlay(teamToPlay.cards.slice(0, 6)))
-            await page.waitForXPath(`//div[@data-original-title="${teamActualSplinterToPlay(teamToPlay.cards.slice(0, 6))}"]`, { timeout: 8000 })
+            const playTeamColor = teamActualSplinterToPlay(teamToPlay.cards.slice(0, 6)) || matchDetails.splinters[0]
+            console.log('Dragon play TEAMCOLOR', playTeamColor)
+            await page.waitForXPath(`//div[@data-original-title="${playTeamColor}"]`, { timeout: 8000 })
                 .then(selector => selector.click())
         }
         await page.waitForTimeout(5000);
@@ -358,6 +359,7 @@ const blockedResources = [
     });
     page.goto('https://splinterlands.io/');
     page.recoverStatus = 0;
+    page.favouriteDeck = process.env.FAVOURITE_DECK || '';
     while (true) {
         console.log('Recover Status: ', page.recoverStatus)
         console.log(chalk.bold.redBright.bgBlack('Dont pay scammers!'));

--- a/possibleTeams.js
+++ b/possibleTeams.js
@@ -46,11 +46,12 @@ const summoners = [{ 224: 'dragon' },
 
 const splinters = ['fire', 'life', 'earth', 'water', 'death', 'dragon']
 
-const getSummoners = (myCards) => {
+const getSummoners = (myCards, splinters) => {
     try {
         const sumArray = summoners.map(x=>Number(Object.keys(x)[0]))
         const mySummoners = myCards.filter(value => sumArray.includes(Number(value)));
-        return mySummoners;             
+        const myAvailableSummoners = mySummoners.filter(id=>splinters.includes(summonerColor(id)))
+        return myAvailableSummoners || mySummoners;             
     } catch(e) {
         console.log(e);
         return [];
@@ -143,7 +144,7 @@ const cardsIdsforSelectedBattles = (mana, ruleset, splinters, summoners) => batt
 
 const askFormation = function (matchDetails) {
     const cards = matchDetails.myCards || basicCards;
-    const mySummoners = getSummoners(cards);
+    const mySummoners = getSummoners(cards,matchDetails.splinters);
     console.log('INPUT: ', matchDetails.mana, matchDetails.rules, matchDetails.splinters, cards.length)
     return cardsIdsforSelectedBattles(matchDetails.mana, matchDetails.rules, matchDetails.splinters, mySummoners)
         .then(x => x.filter(
@@ -207,12 +208,23 @@ const mostWinningSummonerTankCombo = async (possibleTeams, matchDetails) => {
     }
 }
 
-const teamSelection = async (possibleTeams, matchDetails, quest) => {
+const teamSelection = async (possibleTeams, matchDetails, quest, favouriteDeck) => {
     let priorityToTheQuest = process.env.QUEST_PRIORITY === 'false' ? false : true;
     //TEST V2 Strategy ONLY FOR PRIVATE API
     if (process.env.API_VERSION == 2 && possibleTeams[0][8]) {
         // check dragons and remove the non playable:
-        const removedUnplayableDragons = possibleTeams.filter(team=>team[7]!=='dragon' || matchDetails.splinters.includes(helper.teamActualSplinterToPlay(team).toLowerCase()))
+        const removedUnplayableDragons = possibleTeams.filter(team=>team[7]!=='dragon' || matchDetails.splinters.includes(helper.teamActualSplinterToPlay(team?.slice(0, 6)).toLowerCase()))
+        //force favouriteDeck play:
+        if(favouriteDeck && matchDetails.splinters.includes(favouriteDeck?.toLowerCase())) {
+            const filteredTeams = removedUnplayableDragons.filter(team=>team[7]===favouriteDeck)
+            console.log('play splinter:', favouriteDeck, 'from ', filteredTeams?.length, 'teams')
+            if(filteredTeams && filteredTeams.length >= 1 && filteredTeams[0][8]) {
+                console.log('play deck:', filteredTeams[0])
+                return { summoner: filteredTeams[0][0], cards: filteredTeams[0] };
+            }
+            console.log('No possible teams for splinter',favouriteDeck)
+        }
+
         //check quest for private api V2:
         if(priorityToTheQuest && removedUnplayableDragons.length > 25 && quest && quest.total) {
             const left = quest.total - quest.completed;
@@ -220,12 +232,12 @@ const teamSelection = async (possibleTeams, matchDetails, quest) => {
             const filteredTeams = removedUnplayableDragons.filter(team=>team[7]===quest.splinter)
             console.log(left + ' battles left for the '+quest.splinter+' quest')
             console.log('play for the quest ',quest.splinter,'? ',questCheck)
-            if(left > 0 && filteredTeams && filteredTeams.length > 1 && splinters.includes(quest.splinter) && filteredTeams[0][8]) {
-                console.log('PLAY for the quest with Teams size: ',filteredTeams.length, 'PLAY: ', filteredTeams[0][0])
+            if(left > 0 && filteredTeams && filteredTeams.length >= 1 && splinters.includes(quest.splinter) && filteredTeams[0][8]) {
+                console.log('PLAY for the quest with Teams size: ',filteredTeams.length, 'PLAY: ', filteredTeams[0])
                 return { summoner: filteredTeams[0][0], cards: filteredTeams[0] };
             }
         }
-        const filteredTeams = removedUnplayableDragons.filter(team=>matchDetails.splinters.includes(helper.teamActualSplinterToPlay(team).toLowerCase()))
+        const filteredTeams = removedUnplayableDragons.filter(team=>matchDetails.splinters.includes(helper.teamActualSplinterToPlay(team?.slice(0, 6)).toLowerCase()))
         console.log('play the most winning: ', filteredTeams[0])
         return { summoner: filteredTeams[0][0], cards: filteredTeams[0] };
     }
@@ -258,7 +270,7 @@ const teamSelection = async (possibleTeams, matchDetails, quest) => {
 
     let i = 0;
     for (i = 0; i <= possibleTeams.length - 1; i++) {
-        if (matchDetails.splinters.includes(possibleTeams[i][7]) && helper.teamActualSplinterToPlay(possibleTeams[i]) !== '' && matchDetails.splinters.includes(helper.teamActualSplinterToPlay(possibleTeams[i]).toLowerCase())) {
+        if (matchDetails.splinters.includes(possibleTeams[i][7]) && helper.teamActualSplinterToPlay(possibleTeams[i]) !== '' && matchDetails.splinters.includes(helper.teamActualSplinterToPlay(possibleTeams[i]?.slice(0, 6)).toLowerCase())) {
             console.log('Less than 25 teams available. SELECTED: ', possibleTeams[i]);
             const summoner = card.makeCardId(possibleTeams[i][0].toString());
             return { summoner: summoner, cards: possibleTeams[i] };


### PR DESCRIPTION
- Fixed bug for dragon team when the second color (fire, earth,... ) was defined incorrectly by the bot.
- Added favourite deck to play feature (this will be prioritize over the quest if the splinter is available to play and there are enough suggestions)
- Select only summoners available for the match to call API to have a better team selection