### PR TITLE
add reset function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .env
+package-lock.json

--- a/helper.js
+++ b/helper.js
@@ -48,12 +48,18 @@ const getElementText = async (page, selector, timeout=15000) => {
 }
 
 const getElementTextByXpath = async (page, selector, timeout=20000) => {
-	const element = await page.waitForXPath(selector,  { timeout: timeout });
-	const text = await element.evaluate(el => el.textContent);
-	return text;
+	try {
+		const element = await page.waitForXPath(selector,  { timeout: timeout });
+		const text = await element.evaluate(el => el.textContent);
+		return text;
+	} catch (e) {
+		console.log('Get text by xpath error.', e);
+		return false
+	}
 }
 
 module.exports.teamActualSplinterToPlay = teamActualSplinterToPlay;
 module.exports.clickOnElement = clickOnElement;
 module.exports.getElementText = getElementText;
 module.exports.getElementTextByXpath = getElementTextByXpath;
+module.exports.sleep = sleep;


### PR DESCRIPTION
Add restart bot functionality if an error occurred.
Successfully tested on these events:
1. login
2. ECR below ECR_STOP_LIMIT

Refactor codes:
1. anonymous start/main function, named to run
2. ECR check script

Add 2 new functions:
1. closeBrowser
2. restart (to restart the bot)