### PR TITLE
Add default Procfile + unchain 301s

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+worker: npm start -p $PORT

--- a/crawlBattlesData.js
+++ b/crawlBattlesData.js
@@ -44,7 +44,7 @@ async function openSplinter() {
         deviceScaleFactor: 1,
       });
 
-    await page.goto('https://splinterlands.io/?p=battle_history');
+    await page.goto('https://splinterlands.com/?p=battle_history');
     await page.waitForTimeout(2000);
     await login(page)
     await page.waitForTimeout(2000);

--- a/getCards.js
+++ b/getCards.js
@@ -2,7 +2,7 @@
 const fetch = require("node-fetch");
 
 async function getCards() {
-    return await fetch("https://api2.splinterlands.com/cards/get_details?v=1582322601277", {"credentials":"omit","headers":{"accept":"application/json, text/javascript, */*; q=0.01","accept-language":"en-GB,en-US;q=0.9,en;q=0.8"},"referrer":"https://splinterlands.io/?p=collection&a=a1492dc","referrerPolicy":"no-referrer-when-downgrade","body":null,"method":"GET","mode":"cors"})
+    return await fetch("https://api2.splinterlands.com/cards/get_details?v=1582322601277", {"credentials":"omit","headers":{"accept":"application/json, text/javascript, */*; q=0.01","accept-language":"en-GB,en-US;q=0.9,en;q=0.8"},"referrer":"https://splinterlands.com/?p=collection&a=a1492dc","referrerPolicy":"no-referrer-when-downgrade","body":null,"method":"GET","mode":"cors"})
         .then((response) => {
             if (!response.ok) {
             throw new Error('Network response was not ok');

--- a/index.js
+++ b/index.js
@@ -231,7 +231,7 @@ async function startBotPlayMatch(page, browser) {
             deviceScaleFactor: 1,
         });
 
-        await page.goto('https://splinterlands.io/');
+        await page.goto('https://splinterlands.com/');
         await page.waitForTimeout(8000);
 
         let item = await page.waitForSelector('#log_in_button > button', {
@@ -248,7 +248,7 @@ async function startBotPlayMatch(page, browser) {
             });
         }
 
-        await page.goto('https://splinterlands.io/?p=battle_history');
+        await page.goto('https://splinterlands.com/?p=battle_history');
         await page.waitForTimeout(8000);
         await closePopups(page);
         await closePopups(page);
@@ -522,7 +522,7 @@ async function run() {
         const errorMessage = err.toString();
         console.log('browser page error: ', errorMessage)
     });
-    page.goto('https://splinterlands.io/');
+    page.goto('https://splinterlands.com/');
     page.recoverStatus = 0;
     page.favouriteDeck = process.env.FAVOURITE_DECK || '';
     while (start) {


### PR DESCRIPTION
* Added a default Procfile that should work with Heroku out-of-the-box with a PORT variable defined.
* De-chain 301's from the old .io domain for puppeteer.  ^Left .io API calls intact, which seem to _not_ forward.